### PR TITLE
Add a smart mode type to reduce quote escaping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ between
    ```
 
 ## Configuration
-The sting quote type can be configured as either 'single' or 'double' in the configuration
+The string quote type can be configured as either 'single' or 'double' in the configuration
 file. For example, to check for single quote string literals, double quote triple quoted string,
 and double quoted docstrings,
 ```ini
@@ -122,3 +122,8 @@ string-quote=single
 triple-quote=single
 docstring-quote=double
 ```
+
+Additionally the `string-quote` can be configured to avoid escaping: by default
+it enforces one type but if using the other type would avoid some escaping then
+it enforces the other one. To use those smart types the config is
+'single-avoid-escape', and 'double-avoid-escape'.


### PR DESCRIPTION
This enforces strings like `'I don\'t know'` to be quoted as `"I don't know"` even though the default quotes are single quotes.

It should not change the current behavior as it requires a specific config.