### PR TITLE
Bootstrap build process without pylint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,27 @@
 """Setup for the pylint-quotes package.
 """
 
+import os
+import re
 from setuptools import setup, find_packages
 
-from pylint_quotes import __version__
+
+def find_version(*file_paths):
+    """Return version defined in __init__.py without import pylint"""
+    with open(os.path.join(*file_paths)) as fhandler:
+        version_file = fhandler.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
 
 
 setup(
     name='pylint-quotes',
     description='Quote consistency checker for Pylint',
     license='MIT',
-    version=__version__,
+    version=find_version("pylint_quotes", "__init__.py"),
     author='Erick Daniszewski',
     author_email='edaniszewski@gmail.com',
     url='https://github.com/edaniszewski/pylint-quotes',


### PR DESCRIPTION
I met the following error when trying to build the package in a docker container where the `pylint` is not installed. This PR is aiming to avoid importing any dependencies which may not installed yet in `setup.py`.

```
+ pip wheel --no-deps -w /home/vagrant/thirdparty-wheel/results/alpine/pylint-quotes .
---> Sources:
86f79ae93e06a6fc488c7f73924be812  pylint-quotes-0.1.6.tar.gz
/home/vagrant/thirdparty-wheel
/home/vagrant/thirdparty-wheel/builds/pylint-quotes/pylint-quotes-0.1.6 /home/vagrant/thirdparty-wheel
/home/vagrant/thirdparty-wheel
/home/vagrant/thirdparty-wheel/builds/pylint-quotes/pylint-quotes-0.1.6 /home/vagrant/thirdparty-wheel
The directory '/root/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Processing /home/vagrant/thirdparty-wheel/builds/pylint-quotes/pylint-quotes-0.1.6
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-NI5bJu-build/setup.py", line 6, in <module>
        from pylint_quotes import __version__
      File "pylint_quotes/__init__.py", line 4, in <module>
        from pylint_quotes import plugin, checker
      File "pylint_quotes/plugin.py", line 5, in <module>
        from pylint_quotes.checker import StringQuoteChecker
      File "pylint_quotes/checker.py", line 8, in <module>
        from pylint.interfaces import ITokenChecker, IAstroidChecker
    ImportError: No module named pylint.interfaces
```