### PR TITLE
Fix install -- ImportError: No module named 'pylint'

### DIFF
--- a/pylint_quotes/__init__.py
+++ b/pylint_quotes/__init__.py
@@ -1,7 +1,7 @@
 """pylint-quotes module"""
 
 from __future__ import absolute_import
-from pylint_quotes import plugin, checker
+from pylint_quotes import plugin
 
 __version__ = '0.1.6'
 

--- a/pylint_quotes/__init__.py
+++ b/pylint_quotes/__init__.py
@@ -3,6 +3,6 @@
 from __future__ import absolute_import
 from pylint_quotes import plugin
 
-__version__ = '0.1.6'
+__version__ = '0.1.7'
 
 register = plugin.register

--- a/pylint_quotes/plugin.py
+++ b/pylint_quotes/plugin.py
@@ -2,13 +2,11 @@
 for Pylint plugins.
 """
 
-from pylint_quotes.checker import StringQuoteChecker
-
-
 def register(linter):
     """Required method to auto register this checker.
 
     Args:
         linter: Main interface object for Pylint plugins.
     """
+    from pylint_quotes.checker import StringQuoteChecker
     linter.register_checker(StringQuoteChecker(linter))

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 """
 
 from setuptools import setup, find_packages
+#import importlib
 
 from pylint_quotes import __version__
 
@@ -10,7 +11,7 @@ setup(
     name='pylint-quotes',
     description='Quote consistency checker for Pylint',
     license='MIT',
-    version=__version__,
+    version=__version__,#get_version(),
     author='Erick Daniszewski',
     author_email='edaniszewski@gmail.com',
     url='https://github.com/edaniszewski/pylint-quotes',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 """
 
 from setuptools import setup, find_packages
-#import importlib
 
 from pylint_quotes import __version__
 
@@ -11,7 +10,7 @@ setup(
     name='pylint-quotes',
     description='Quote consistency checker for Pylint',
     license='MIT',
-    version=__version__,#get_version(),
+    version=__version__,
     author='Erick Daniszewski',
     author_email='edaniszewski@gmail.com',
     url='https://github.com/edaniszewski/pylint-quotes',


### PR DESCRIPTION
Had issues with `import pylint` being in the same scope as the `__init__.__version__` lookup.  Sanitized initial import so `python setup.py install --force` works.

Is a blocking issue with including `pylint-quotes` inside a `readthedocs` project.