### PR TITLE
Don't pass `col_offset` to add message for 1.9 branch of pylint

### DIFF
--- a/pylint_quotes/checker.py
+++ b/pylint_quotes/checker.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 import tokenize
 
+from pylint.__pkginfo__ import numversion as pylint_version
 from pylint.checkers import BaseTokenChecker
 from pylint.interfaces import IAstroidChecker, ITokenChecker
 
@@ -337,8 +338,13 @@ class StringQuoteChecker(BaseTokenChecker):
             'invalid-string-quote',
             line=row,
             args=(quote, correct_quote),
-            col_offset=col,
+            **self.get_offset(col)
         )
+
+    def get_offset(self, col):
+        if (2, 2, 2) < pylint_version:
+            return {'col_offset': col}
+        return {}
 
     def _invalid_triple_quote(self, quote, row, col=None):
         """Add a message for an invalid triple quote.
@@ -352,7 +358,7 @@ class StringQuoteChecker(BaseTokenChecker):
             'invalid-triple-quote',
             line=row,
             args=(quote, TRIPLE_QUOTE_OPTS.get(self.config.triple_quote)),
-            col_offset=col,
+            **self.get_offset(col)
         )
 
     def _invalid_docstring_quote(self, quote, row, col=None):
@@ -367,5 +373,5 @@ class StringQuoteChecker(BaseTokenChecker):
             'invalid-docstring-quote',
             line=row,
             args=(quote, TRIPLE_QUOTE_OPTS.get(self.config.docstring_quote)),
-            col_offset=col,
+            **self.get_offset(col)
         )

--- a/pylint_quotes/checker.py
+++ b/pylint_quotes/checker.py
@@ -341,7 +341,22 @@ class StringQuoteChecker(BaseTokenChecker):
             **self.get_offset(col)
         )
 
-    def get_offset(self, col):
+    @staticmethod
+    def get_offset(col):
+        """Return kwargs to pass to add_message.
+
+        col_offset is not present in all versions of pylint, so
+        attempt to determine if col_offset is supported, if so
+        return a dictionary returning col_offset otherwise return
+        {}.
+
+        Args:
+            col: The integer column offset to possibly include in
+                the kwargs.
+
+        Returns:
+            dict: Keyword arguments to pass to add_message
+        """
         if (2, 2, 2) < pylint_version:
             return {'col_offset': col}
         return {}


### PR DESCRIPTION
col_offset as a kwarg to add_message seems to have been added to the 2.X branch but not the 1.X branch of pylint.  The upshot of this is that pylint-quotes fails with 
```
TypeError: add_message() got an unexpected keyword argument 'col_offset'
```
for the 1.X branch of pylint (specifically 1.9.4).