### PR TITLE
remove __implements__ to support pylint>=3.0.0

### DIFF
--- a/pylint_quotes/checker.py
+++ b/pylint_quotes/checker.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import tokenize
 
 from pylint.checkers import BaseTokenChecker
-from pylint.interfaces import IAstroidChecker, ITokenChecker
 
 try:
     from pylint import version as pv
@@ -37,8 +36,6 @@ class StringQuoteChecker(BaseTokenChecker):
     enforcing single quotes (') most of the time, except if the string itself
     contains a single quote, then enforce double quotes (").
     """
-
-    __implements__ = (ITokenChecker, IAstroidChecker, )
 
     name = 'string_quotes'
 


### PR DESCRIPTION
https://github.com/pylint-dev/pylint/issues/9094

this PR removes `__implements__` to support pylint.